### PR TITLE
bump up leveldown to 1.0 per #7

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "main": "level.js",
   "dependencies": {
-    "leveldown": "~0.10.0",
+    "leveldown": "~1.0.0",
     "level-packager": "~0.18.0",
     "level-js": "~1.1.2"
   },


### PR DESCRIPTION
For https://github.com/Level/level-browserify/issues/7

On a browser, I ran the equivalent of the test in the readme (put name=LevelUP and get and print name) and it passed.