### PR TITLE
Updated to Level-1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,15 @@
-language: c
+language: node_js
 
 before_install:
-  - rm -rf ~/.nvm
-  - wget https://raw.githubusercontent.com/visionmedia/n/master/bin/n -qO n
-  - chmod +x n
-  - sudo cp n /usr/local/bin/n
-  - sudo chmod -R a+xw /usr/local
-  - n --version
+  - export JOBS=max
+  - npm install -g node-gyp-install
+  - node-gyp-install
 
-branches:
-  only:
-    - master
+node_js:
+  - "2.2"
+  - "1.8"
+  - "0.12"
+  - "0.10"
 
 script:
-  - n io latest
-  - iojs -v; npm -v;
-  - JOBS=max npm install
-  - npm test && rm -rf node_modules/
-
-  - n 0.12
-  - node -v; npm -v;
-  - JOBS=max npm install
-  - npm test && rm -rf node_modules/
-
-  - n 0.10
-  - node -v; npm -v;
-  - JOBS=max npm install
-  - npm test && rm -rf node_modules/
-
-  - n 0.8
-  - npm install npm -g
-  - node -v; npm -v;
-  - JOBS=max npm install
-  - npm test && rm -rf node_modules/
-
-notifications:
-  email:
-    - r@va.gg
-    - john@chesl.es
-    - raynos2@gmail.com
-    - dominic.tarr@gmail.com
-    - max@maxogden.com
-    - ralphtheninja@riseup.net
-    - david.bjorklund@gmail.com
-    - julian@juliangruber.com
-    - paolo@async.ly
-    - anton.whalley@nearform.com
-    - matteo.collina@gmail.com
-    - pedro.teixeira@gmail.com
-    - mail@substack.net
+  - npm test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Level-browserify
 
 [![Build Status](https://secure.travis-ci.org/Level/level-browserify.png)](http://travis-ci.org/Level/level-browserify)
 
-[![NPM](https://nodei.co/npm/level-browserify.png?stars&downloads)](https://nodei.co/npm/level-browserify/) [![NPM](https://nodei.co/npm-dl/level.png)](https://nodei.co/npm/level/)
+[![NPM](https://nodei.co/npm/level-browserify.png?stars&downloads)](https://nodei.co/npm/level-browserify/) [![NPM](https://nodei.co/npm-dl/level-browserify.png)](https://nodei.co/npm/level-browserify/)
 
 
 This is a convenience package that bundles the current release of **[LevelUP](https://github.com/level/levelup)** and **[LevelDOWN](https://github.com/level/leveldown)**/**[Level.js](https://github.com/maxogden/level.js)** and exposes LevelUP on its export.

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   ],
   "main": "level.js",
   "dependencies": {
-    "level-js": "^2.1.6",
-    "level-packager": "^1.0.0",
-    "leveldown": "^1.2.2"
+    "level-js": "~2.1.6",
+    "level-packager": "~1.1.0",
+    "leveldown": "~1.2.2"
   },
   "browser": "browser.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "main": "level.js",
   "dependencies": {
     "level-js": "^2.1.6",
-    "level-packager": "~0.19.0",
-    "leveldown": "~0.10.0"
+    "level-packager": "^1.0.0",
+    "leveldown": "^1.2.2"
   },
   "browser": "browser.js",
   "devDependencies": {


### PR DESCRIPTION
Updated dependencies.

I suggest we bump this to 1.0.0.

However, it does not include the latest levelup because of https://github.com/Level/packager/issues/20.

Closes #8.