### PR TITLE
Updated leveldown to 1.4.1 so that the build works in Node v4.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "level-browserify",
   "description": "Fast & simple storage - a Node.js-style LevelDB wrapper (a convenience package bundling LevelUP & LevelDOWN or Level.js)",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "contributors": [
     "Rod Vagg <r@va.gg> (https://github.com/rvagg)",
     "John Chesley <john@chesl.es> (https://github.com/chesles/)",
@@ -36,7 +36,7 @@
   "dependencies": {
     "level-js": "~2.1.6",
     "level-packager": "~1.1.0",
-    "leveldown": "~1.2.2"
+    "leveldown": "^1.4.1"
   },
   "browser": "browser.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "level-browserify",
   "description": "Fast & simple storage - a Node.js-style LevelDB wrapper (a convenience package bundling LevelUP & LevelDOWN or Level.js)",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "contributors": [
     "Rod Vagg <r@va.gg> (https://github.com/rvagg)",
     "John Chesley <john@chesl.es> (https://github.com/chesles/)",


### PR DESCRIPTION
With leveldown 1.4.1, tests pass and the example in the README works. Anyone know if leveldown [1.2.2 to 1.4.1](https://github.com/Level/leveldown/compare/v1.2.2...bcbf8775787f0f07ac18055ca7e18da6d1e7ce0b) is a fairly safe update?