### PR TITLE
Simplifying level-packager call for level-js

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,6 +1,2 @@
 
-var Leveljs = require('level-js')
-
-module.exports = require('level-packager')(function(l) {
-  return new Leveljs(l)
-})
+module.exports = require('level-packager')(require('level-js'))


### PR DESCRIPTION
I noticed that [level-js was not properly loaded](https://github.com/Level/level-browserify/issues/30) when using browserify.  After digging into level-packager a bit I think this call may be a more appropriate.  After making this change level-js appears to work correctly when using browserify.